### PR TITLE
fix(fonts): evita flash da fonte pixelada no banner

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -8,6 +8,17 @@ import LanguageDetector from 'i18next-browser-languagedetector';
 import translatePt from './config/translate/pt';
 import translateEn from './config/translate/en';
 import translateEs from './config/translate/es';
+import pressStart2pWoff2 from '@fontsource/press-start-2p/files/press-start-2p-latin-400-normal.woff2';
+
+// Preload da fonte pixelada usada no titulo do banner (LCP) para evitar o flash
+// com a fonte de fallback enquanto o Press Start 2P carrega.
+const fontPreload = document.createElement('link');
+fontPreload.rel = 'preload';
+fontPreload.as = 'font';
+fontPreload.type = 'font/woff2';
+fontPreload.crossOrigin = 'anonymous';
+fontPreload.href = pressStart2pWoff2;
+document.head.appendChild(fontPreload);
 
 i18next
   .use(LanguageDetector)

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -1,8 +1,8 @@
 @import '@fontsource-variable/geist';
 @import '@fontsource-variable/geist-mono';
 @import '@fontsource-variable/space-grotesk';
-@import '@fontsource/press-start-2p/400.css';
-@import '@fontsource/vt323/400.css';
+@import '@fontsource/press-start-2p/latin-400.css';
+@import '@fontsource/vt323/latin-400.css';
 
 @import 'tailwindcss';
 


### PR DESCRIPTION
A fonte pixelada (Press Start 2P) do titulo do banner carregava de forma assincrona, causando um flash com a fonte de fallback (monospace) antes de aparecer o visual pixelado. Este ajuste ficou de fora da PR #160 (que ja foi mergeada).

## Correcao

- **Preload** do woff2 do Press Start 2P (subset latin) via Vite em `src/index.js`, resolvendo o hash automaticamente. A fonte baixa cedo e o titulo ja aparece pixelado no primeiro paint.
- **Subset latin** em vez de todos os subsets em `globals.css` (12,5 KB, cobre os caracteres acentuados do titulo como Ã e Õ), encurtando a janela de carregamento.

## Validacao

- `npm run build` passa, fonte emitida como asset hasheado
- Preload aponta para o mesmo woff2 do `@font-face` (o navegador reaproveita o download)
- Fonte pixelada aplicada no titulo confirmada via medicao de glyph
