### PR TITLE
fix(fonts): corrige fontes 404 em producao apos migracao Tailwind v4

### DIFF
--- a/src/routes/index.js
+++ b/src/routes/index.js
@@ -1,6 +1,15 @@
 import React, { Suspense, lazy, useEffect, useState } from 'react';
 import { BrowserRouter as Router, Navigate, Route, Routes, useLocation } from 'react-router-dom';
 
+// Fontes importadas via JS (nao via @import no CSS) para que o Vite resolva os
+// url() relativos e hasheie os woff2. Com o pipeline do Tailwind v4, o @import
+// no globals.css deixava esses caminhos sem resolver, gerando 404 em producao.
+import '@fontsource-variable/geist';
+import '@fontsource-variable/geist-mono';
+import '@fontsource-variable/space-grotesk';
+import '@fontsource/press-start-2p/latin-400.css';
+import '@fontsource/vt323/latin-400.css';
+
 import '../styles/globals.css';
 
 import Home from '../pages/home';

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -1,9 +1,3 @@
-@import '@fontsource-variable/geist';
-@import '@fontsource-variable/geist-mono';
-@import '@fontsource-variable/space-grotesk';
-@import '@fontsource/press-start-2p/latin-400.css';
-@import '@fontsource/vt323/latin-400.css';
-
 @import 'tailwindcss';
 
 @config '../../tailwind.config.js';


### PR DESCRIPTION
## Problema

Em producao, NENHUMA fonte do fontsource carregava (Geist, Space Grotesk, VT323 e Press Start 2P), caindo todas no fallback. No banner isso ficava visivel: o titulo "JOÃO VICTOR SOUZA" perdia a fonte pixelada (Press Start 2P) e renderizava com monospace generico.

## Causa raiz

Regressao introduzida na migracao para Tailwind v4 (PR #160). Os `@import` dos CSS de fonte estavam dentro do `globals.css`. Com o novo pipeline `@tailwindcss/postcss`, o Vite deixava de reescrever os `url()` relativos desses CSS, gerando no build de producao:

```
@font-face { ... src: url(./files/press-start-2p-latin-400-normal.woff2) ... }
```

O caminho `./files/...` nao existe em `build/assets/` (o arquivo real e hasheado, ex. `press-start-2p-latin-400-normal-_wFEWmAB.woff2`), resultando em 404 e fonte nao carregada. Em dev funcionava porque o Vite serve `node_modules` direto, mascarando o problema. Os avisos "didn't resolve at build time" no build eram justamente este bug.

## Correcao

Movidos os imports de fonte do `@import` no `globals.css` para imports JS em `src/routes/index.js` (antes do globals.css). Assim o Vite processa cada CSS de fonte e reescreve/hasheia os `url()` corretamente.

## Validacao (build de producao)

- Antes: dezenas de avisos `didn't resolve at build time`; CSS com `url(./files/...)` quebrado
- Depois: **0** avisos; CSS referencia os woff2 hasheados; **0** `url(./files/...)` orfaos
- Todas as fontes emitidas como assets hasheados
- `@font-face` e preload agora apontam para o mesmo arquivo real
- Em dev: Press Start 2P, Geist e Space Grotesk carregam; titulo pixelado confirmado (144px vs 79px monospace)
